### PR TITLE
Publish releases to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,14 +2,15 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
-  package:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -17,15 +18,45 @@ jobs:
         with:
           node-version: 24
           package-manager-cache: false
-      - run: npm install --global pnpm@11.17.0
-      - run: pnpm install --frozen-lockfile
-      - name: Verify tag matches package version
-        run: test "$GITHUB_REF_NAME" = "v$(node -p "require('./package.json').version")"
-      - run: pnpm exec playwright install --with-deps chromium
-      - run: pnpm run package:plugin
-      - name: Prepare stable asset name
-        run: mv dist/dsh-plugin-genui-*.tgz dist/dsh-plugin-genui.tgz
-      - name: Publish release
+          registry-url: https://registry.npmjs.org
+      - name: Check release state
+        id: release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "$GITHUB_REF_NAME" dist/dsh-plugin-genui.tgz --generate-notes --title "$GITHUB_REF_NAME"
+        run: |
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          if npm view "$name@$version" version >/dev/null 2>&1; then
+            echo "npm_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "npm_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+          if gh release view "v$version" >/dev/null 2>&1; then
+            echo "github_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "github_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.release.outputs.npm_exists == 'false' || steps.release.outputs.github_exists == 'false'
+        run: npm install --global pnpm@11.17.0
+      - if: steps.release.outputs.npm_exists == 'false' || steps.release.outputs.github_exists == 'false'
+        run: pnpm install --frozen-lockfile
+      - if: steps.release.outputs.npm_exists == 'false' || steps.release.outputs.github_exists == 'false'
+        run: pnpm exec playwright install --with-deps chromium
+      - if: steps.release.outputs.npm_exists == 'false' || steps.release.outputs.github_exists == 'false'
+        run: pnpm run package:plugin
+      - name: Prepare stable asset name
+        if: steps.release.outputs.npm_exists == 'false' || steps.release.outputs.github_exists == 'false'
+        run: mv dist/dsh-plugin-genui-*.tgz dist/dsh-plugin-genui.tgz
+      - name: Publish GitHub release
+        if: steps.release.outputs.github_exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="${{ steps.release.outputs.version }}"
+          gh release create "v$version" dist/dsh-plugin-genui.tgz --target "$GITHUB_SHA" --generate-notes --title "v$version"
+      - name: Publish npm package
+        if: steps.release.outputs.npm_exists == 'false'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish ./dist/dsh-plugin-genui.tgz --access public --provenance

--- a/README.md
+++ b/README.md
@@ -87,8 +87,7 @@ Open **Settings → Plugins → Plugin configuration** to use automatic selectio
 Use Node.js `^22.19.0 || >=24`. This release is tested with DeepSeek Harness `0.1.0-rc.6` and Cordis `4.0.0-rc.7`.
 
 ```sh
-curl -fL https://github.com/pengyue-polaron/deepseek-harness-genui/releases/latest/download/dsh-plugin-genui.tgz -o /tmp/dsh-plugin-genui.tgz
-dsh plugin --profile web add /tmp/dsh-plugin-genui.tgz
+dsh plugin --profile web add dsh-plugin-genui
 dsh plugin --profile web exec playwright install chromium
 dsh --profile web
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -87,8 +87,7 @@ Inline、Canvas、全屏和本地页面共享同一份任务状态。用户在�
 使用 Node.js `^22.19.0 || >=24`。当前版本在 DeepSeek Harness `0.1.0-rc.6` 和 Cordis `4.0.0-rc.7` 上通过测试。
 
 ```sh
-curl -fL https://github.com/pengyue-polaron/deepseek-harness-genui/releases/latest/download/dsh-plugin-genui.tgz -o /tmp/dsh-plugin-genui.tgz
-dsh plugin --profile web add /tmp/dsh-plugin-genui.tgz
+dsh plugin --profile web add dsh-plugin-genui
 dsh plugin --profile web exec playwright install chromium
 dsh --profile web
 ```

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "dsh-plugin-genui",
   "description": "Code-first generative UI artifacts for DeepSeek Harness",
-  "version": "0.12.1",
-  "private": true,
+  "version": "0.12.2",
   "keywords": [
     "deepseek-harness",
     "dsh-plugin",


### PR DESCRIPTION
Publish `dsh-plugin-genui` as a prebuilt npm package and keep GitHub Releases in the same main-branch release workflow.

- release `0.12.2` and remove the private package flag
- publish only when the package version is new
- create the matching GitHub Release from the same tarball
- switch English and Chinese installation docs to the npm package name
- keep credentials in the `NPM_TOKEN` Actions secret

Validation: 63 tests pass, build succeeds, and `npm publish --dry-run` accepts the 1.16 MB package.