### PR TITLE
Release v0.13.2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -984,7 +984,7 @@ function isGranted(record, sessionId, capability) {
 
 //#endregion
 //#region src/runtime/standalone.ts
-const ARTIFACT_RUNTIME_VERSION = "0.13.1";
+const ARTIFACT_RUNTIME_VERSION = "0.13.2";
 const STANDALONE_RUNTIME = String.raw`
 const root = document.body
 const frame = document.getElementById('app')

--- a/lib/types/runtime/standalone.d.ts
+++ b/lib/types/runtime/standalone.d.ts
@@ -1,4 +1,4 @@
-export declare const ARTIFACT_RUNTIME_VERSION = "0.13.1";
+export declare const ARTIFACT_RUNTIME_VERSION = "0.13.2";
 export declare const STANDALONE_RUNTIME: string;
 export declare function standaloneHtml(routePrefix: string, artifactId: string, versionId: string, title: string, language: 'en' | 'zh'): string;
 //# sourceMappingURL=standalone.d.ts.map

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-plugin-genui",
   "description": "Task-specific React apps for DeepSeek Harness with state carried into the next Agent turn",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "keywords": [
     "deepseek-harness",
     "dsh-plugin",

--- a/src/runtime/standalone.ts
+++ b/src/runtime/standalone.ts
@@ -1,4 +1,4 @@
-export const ARTIFACT_RUNTIME_VERSION = '0.13.1'
+export const ARTIFACT_RUNTIME_VERSION = '0.13.2'
 
 export const STANDALONE_RUNTIME = String.raw`
 const root = document.body


### PR DESCRIPTION
Closes #6.

Publishes the keyed settings-slot compatibility fix from #5.

Validation:
- `pnpm run package:plugin`
- 17 test files, 77 passed, 1 skipped
- clean rebuild parity for committed `lib`
- packed artifact inspected as `dsh-plugin-genui@0.13.2`