### PR TITLE
Fix marketplace screenshot discovery

### DIFF
--- a/screenshots.json
+++ b/screenshots.json
@@ -1,0 +1,7 @@
+[
+  "screenshots/en/code-path-canvas.jpg",
+  "screenshots/en/code-path-inline.jpg",
+  "screenshots/en/photosynthesis-explorer.jpg",
+  "screenshots/en/calendar-planner.jpg",
+  "screenshots/en/code-path-explorer.jpg"
+]


### PR DESCRIPTION
The marketplace still has five old `.png` URLs for this plugin, but the screenshots were renamed to `.jpg`, so all five now return 404.

Add the repository-owned `screenshots.json` requested by awesome-dsh-plugin so future builds read the current files directly.

Checked that the JSON parses and every listed file exists.